### PR TITLE
Options page improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,8 @@
   ],
   "default_locale": "en",
   "options_ui": {
-    "page": "options.html"
+    "page": "options.html",
+    "browser_style": true
   },
   "permissions": [
     "storage"

--- a/options.css
+++ b/options.css
@@ -14,3 +14,7 @@ body {
   background-color: var(--page-bg-color);
   color: var(--page-fg-color);
 }
+
+li{
+  margin: 7px 0;
+}

--- a/options.css
+++ b/options.css
@@ -1,0 +1,16 @@
+:root {
+  --page-bg-color: #fff;
+  --page-fg-color: #15141a;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-bg-color: #23222b;
+    --page-fg-color: #fbfbfe;
+  }
+}
+
+body {
+  background-color: var(--page-bg-color);
+  color: var(--page-fg-color);
+}

--- a/options.html
+++ b/options.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <link rel="stylesheet" href="options.css">
   <title data-l10n-id="optionsTitle">Options</title>
   <style>
     ul {
@@ -9,10 +10,6 @@
     }
     body {
       white-space: nowrap;
-    }
-    html, body {
-      background-color: #000000;
-      color: #ffffff;
     }
   </style>
 </head>


### PR DESCRIPTION
Set browser_style for options page and make it follow system theme mode

browser_style itself doesn't follow the theme mode https://bugzilla.mozilla.org/show_bug.cgi?id=1593355
so we add our own css

Also make the colors closer to Firefox's page colour

Add some spacing to list items to fill out available space

This prevents showing a white border

<details>
<summary> Images </summary>

If you add more items:

![long-lists](https://github.com/Edwin-Zarco/refined-h264ify/assets/62639087/cab89b82-d04a-4481-a4e5-52816600b626)


Dark mode: 

![dark mode](https://github.com/Edwin-Zarco/refined-h264ify/assets/62639087/af8dcbfd-0e43-4d57-8cda-dcae50414667)


Light mode:

![light mode](https://github.com/Edwin-Zarco/refined-h264ify/assets/62639087/f0dc5849-3b82-45ff-8d39-717157685ec1)

</details>

Fixes https://github.com/Edwin-Zarco/refined-h264ify/issues/2